### PR TITLE
Add Pattern URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm start 8754
     - `time` -- fade & blink time in seconds (default: 0.1)
     - `ledn` -- LED to control (0=both, 1=top, 2=bottom; default: 0)
     - `repeats` -- number of times to blink (default: 3)
+- `/blink1/pattern` -- blink a pattern of colors, query args:
+    - `rgb` -- hex color codes separated by a comma (,) (e.g. "`#ff00ff`") [required]
+    - `time` -- blink time in seconds (default: 0.1)
+    - `repeats` -- number of times to blink pattern (default: 3)
 
 ### Examples:
 ```
@@ -60,6 +64,23 @@ $ curl  'http://localhost:8754/blink1/fadeToRGB?rgb=%230000ff&time=2.5&ledn=2'
     "lastLedn": 2,
     "lastRepeats": 0,
     "cmd": "fadeToRGB",
+    "status": "success"
+}
+
+$ curl  'http://localhost:8754/blink1/pattern?rgb=%23ff0000,%23ffffff,%230000ff&time=.2&repeats=8'
+{
+    "blink1Connected": true,
+    "blink1Serials": [
+        "200026C1"
+    ],
+    "time": 0.2,
+    "colors": [
+        "#ff0000",
+        "#ffffff",
+        "#0000ff"
+    ],
+    "repeats": 8,
+    "cmd": "pattern",
     "status": "success"
 }
 ```

--- a/main.js
+++ b/main.js
@@ -66,6 +66,12 @@ var blink1Blink = function( onoff, repeats, millis, r, g, b, ledn ) {
     }
 };
 
+var blink1Pattern = function(time, rgb, position) {
+    blink1TryConnect();
+    blink1.writePatternLine(time * 1000 / 2, rgb[0], rgb[1], rgb[2], position*2);
+    blink1.writePatternLine(time * 1000 / 2, 0, 0, 0, position*2+1);    
+};
+
 app.get('/blink1', function(req, res) {
     blink1TryConnect();
     var response = {
@@ -136,6 +142,36 @@ app.get('/blink1/blink', function(req, res) {
         cmd: "blink1",
         status: status
     };
+    res.json( response );
+});
+
+app.get('/blink1/pattern', function(req, res) {
+    var colors = req.query.rgb.split(',');
+    var time = Number(req.query.time) || 0.1;
+    var repeats = Number(req.query.repeats) || Number(req.query.count) || 3;
+    var status = "success";
+
+    for (var i = 0, len = colors.length; i < len && i < 6; i++) {
+        var rgb = parsecolor(colors[i]).rgb;
+        blink1Pattern(time, rgb, i);
+    }
+
+    blink1.playLoop(0, colors.length > 6 ? 11 : colors.length*2-1, repeats);
+
+    if (colors.length > 6) {
+        status =  "can only display first 6 colors. " + colors.length + " colors specified"
+    }
+
+    var response = {
+        blink1Connected: blink1 !== null,
+        blink1Serials: devices,
+        time: time,
+        colors: colors,
+        repeats: repeats,
+        cmd: "pattern",
+        status: status
+    };
+
     res.json( response );
 });
 

--- a/main.js
+++ b/main.js
@@ -185,6 +185,8 @@ app.get('/', function(req, res) {
         " -- status info\n" +
         "<li>   <code> /blink1/fadeToRGB?rgb=%23FF00FF&time=1.5&ledn=2 </code> " +
         "-- fade to a RGB color over time for led\n" +
+       "<li>   <code> /blink1/pattern?rgb=%23ff0000,%23ffffff,%230000ff&time=.2&repeats=8 </code> " +
+        "-- blink a sequence of colors\n" +
         "</ul></p>\n" +
         "When starting server, argument specified is port to run on, e.g.:" +
         "<code> blink1-server 8080 </code>\n" +


### PR DESCRIPTION
## Intro

This PR adds the ability address the issue in todbot/node-blink1-server#1. 
## Body

It adds a pattern endpoint that allows to send a list of colors (up to six, separated with a comma) to display on the blink(1).

 `/blink1/pattern` -- blink a pattern of colors, query args:
    - `rgb` -- hex color codes separated by a comma (,) (e.g. "`#ff00ff`") [required]
    - `time` -- blink time in seconds (default: 0.1)
    - `repeats` -- number of times to blink pattern (default: 3)
## Example call

```
$ curl  'http://localhost:8754/blink1/pattern?rgb=%23ff0000,%23ffffff,%230000ff&time=.2&repeats=8'
{
    "blink1Connected": true,
    "blink1Serials": [
        "200026C1"
    ],
    "time": 0.2,
    "colors": [
        "#ff0000",
        "#ffffff",
        "#0000ff"
    ],
    "repeats": 8,
    "cmd": "pattern",
    "status": "success"
}
```
