### PR TITLE
Container for running node-blink1-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  blink1-node:
+    build: .
+    container_name: blink1-node
+    network_mode: bridge
+    ports:
+      - "8081:8080"
+    devices:
+      - /dev/hidraw0

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,25 @@
+FROM arm32v7/node:8.16.1-alpine 
+
+# add necessary usb libraries
+RUN apk add --update --quiet libusb libusb-dev eudev-dev git
+# add build environment (will be deleted later)
+RUN apk add --no-cache --virtual .gyp python2 make g++ linux-headers
+
+# install blink1-server npm version
+RUN npm config set user root
+RUN npm install --silent -g node-blink1-server
+
+# git repo version
+#RUN git clone https://github.com/todbot/node-blink1-server.git
+#RUN cd node-blink1-server && npm install
+
+# cleanup
+RUN apk del --quiet .gyp git && rm -rf /var/cache/apk
+
+EXPOSE 8080
+
+# for git repo version
+#ENTRYPOINT ["npm", "--prefix", "/node-blink1-server", "start", "8080"]
+
+# for npm version
+ENTRYPOINT ["blink1-server", "8080"]


### PR DESCRIPTION
I'm not sure if this is supposed to go into this repo, in some ignored subfolder or something - but I wanted to share.

- builds container that works on **arm32** architecture (e.g. raspberrypi)
- necessary to change arch and maybe USB libraries for other systems
- `docker-compose` uses device `/dev/hidraw0` as blink(1) USB device - this may be different per system
- `dockerfile` to build docker image using current node LTS version
- exposes port 8080 (can be changed in `docker-compose`)

You can run it with `docker-compose up -d` in the current directory or for testing purposes with:
```
$ docker build -t blink1-node .
$ docker stop blink1-node; docker rm blink1-node; docker run -d -it -p 8080:8080 --device=/dev/hidraw0 --name blink1-node blink1-node; docker exec -it blink1-node /bin/sh
```